### PR TITLE
Add Tado AIR_CONDITIONING sensor

### DIFF
--- a/homeassistant/components/climate/tado.py
+++ b/homeassistant/components/climate/tado.py
@@ -40,10 +40,19 @@ FAN_MODES_LIST = {
     CONST_MODE_OFF: 'Off',
 }
 
-OPERATION_LIST = {
+OPERATION_MANUAL_COOL = {
+    CONST_OVERLAY_MANUAL: 'Manual (Cool)',
+    CONST_OVERLAY_TIMER: 'Timer (Cool)',
+    CONST_OVERLAY_TADO_MODE: 'Tado mode (Cool)',
+}
+
+OPERATION_MANUAL = {
     CONST_OVERLAY_MANUAL: 'Manual',
     CONST_OVERLAY_TIMER: 'Timer',
     CONST_OVERLAY_TADO_MODE: 'Tado mode',
+}
+
+OPERATION_LIST = {
     CONST_MODE_SMART_SCHEDULE: 'Smart schedule',
     CONST_MODE_OFF: 'Off',
 }
@@ -79,25 +88,30 @@ def create_climate_device(tado, hass, zone, name, zone_id):
 
     unit = TEMP_CELSIUS
     device_type = capabilities['type']
+    min_temp = {}
+    max_temp = {}
 
     if CONST_MODE_COOL in capabilities:
         temperatures = capabilities[CONST_MODE_COOL]['temperatures']
+        min_temp[CONST_MODE_COOL]=hass.config.units.temperature(float(temperatures['celsius']['min']), unit)
+        max_temp[CONST_MODE_COOL]=hass.config.units.temperature(float(temperatures['celsius']['max']), unit)
     elif CONST_MODE_HEAT in capabilities:
         temperatures = capabilities[CONST_MODE_HEAT]['temperatures']
+        min_temp[CONST_MODE_HEAT]=hass.config.units.temperature(float(temperatures['celsius']['min']), unit)
+        max_temp[CONST_MODE_HEAT]=hass.config.units.temperature(float(temperatures['celsius']['max']), unit)
     elif 'temperatures' in capabilities:
         temperatures = capabilities['temperatures']
+        min_temp[CONST_MODE_HEAT]=hass.config.units.temperature(float(temperatures['celsius']['min']), unit)
+        max_temp[CONST_MODE_HEAT]=hass.config.units.temperature(float(temperatures['celsius']['max']), unit)
     else:
         _LOGGER.debug("Received zone %s has no temperature; not adding", name)
         return
 
-    min_temp = float(temperatures['celsius']['min'])
-    max_temp = float(temperatures['celsius']['max'])
-
     data_id = 'zone {} {}'.format(name, zone_id)
     device = TadoClimate(tado,
                          name, zone_id, data_id,
-                         hass.config.units.temperature(min_temp, unit),
-                         hass.config.units.temperature(max_temp, unit),
+                         min_temp,
+                         max_temp,
                          device_type)
 
     tado.add_sensor(data_id, {
@@ -108,7 +122,6 @@ def create_climate_device(tado, hass, zone, name, zone_id):
     })
 
     return device
-
 
 class TadoClimate(ClimateDevice):
     """Representation of a tado climate device."""
@@ -123,7 +136,7 @@ class TadoClimate(ClimateDevice):
         self.zone_name = zone_name
         self.zone_id = zone_id
 
-        self.device_type = device_type
+        self._device_type = device_type
 
         self._active = False
         self._device_is_active = False
@@ -136,8 +149,7 @@ class TadoClimate(ClimateDevice):
         self._max_temp = max_temp
         self._target_temp = None
         self._tolerance = tolerance
-        self._cooling = False
-        self._ac_mode = None
+        self._mode = None
         self._current_fan = CONST_MODE_OFF
         self._current_operation = CONST_MODE_SMART_SCHEDULE
         self._overlay_mode = CONST_MODE_SMART_SCHEDULE
@@ -165,26 +177,33 @@ class TadoClimate(ClimateDevice):
     @property
     def current_operation(self):
         """Return current readable operation mode."""
-        if self._cooling:
-            return "Cooling"
+        if self._current_operation in OPERATION_MANUAL:
+            if self._mode == CONST_MODE_COOL:
+                return OPERATION_MANUAL_COOL.get(self._current_operation)
+            return OPERATION_MANUAL.get(self._current_operation)
         return OPERATION_LIST.get(self._current_operation)
 
     @property
     def operation_list(self):
         """Return the list of available operation modes (readable)."""
-        return list(OPERATION_LIST.values())
+        operations = list(OPERATION_LIST.values())
+        if CONST_MODE_COOL in self._min_temp:
+            operations.extend(list(OPERATION_MANUAL_COOL.values()))
+        elif CONST_MODE_HEAT in self._min_temp:
+            operations.extend(list(OPERATION_MANUAL.values()))
+        return operations
 
     @property
     def current_fan_mode(self):
         """Return the fan setting."""
-        if self.device_type == "AIR_CONDITIONING":
+        if self._device_type == "AIR_CONDITIONING":
             return FAN_MODES_LIST.get(self._current_fan)
         return None
 
     @property
     def fan_list(self):
         """List of available fan modes."""
-        if self.device_type == "AIR_CONDITIONING":
+        if self._device_type == "AIR_CONDITIONING":
             return list(FAN_MODES_LIST.values())
         return None
 
@@ -223,14 +242,25 @@ class TadoClimate(ClimateDevice):
     def set_operation_mode(self, readable_operation_mode):
         """Set new operation mode."""
         operation_mode = CONST_MODE_SMART_SCHEDULE
-
-        for mode, readable in OPERATION_LIST.items():
+        mode = None
+        for operation, readable in OPERATION_LIST.items():
             if readable == readable_operation_mode:
-                operation_mode = mode
+                operation_mode = operation
+                break
+        for operation, readable in OPERATION_MANUAL_COOL.items():
+            if readable == readable_operation_mode:
+                operation_mode = operation
+                mode = CONST_MODE_COOL
+                break
+        for operation, readable in OPERATION_MANUAL.items():
+            if readable == readable_operation_mode:
+                operation_mode = operation
+                mode = CONST_MODE_HEAT
                 break
 
         self._current_operation = operation_mode
         self._overlay_mode = None
+        self._mode = mode
         self._control_heating()
 
     @property
@@ -238,8 +268,8 @@ class TadoClimate(ClimateDevice):
         """Return the minimum temperature."""
         temperature = DEFAULT_MIN_TEMP
 
-        if self._min_temp:
-            temperature = self._min_temp
+        if self._mode in self._min_temp:
+            temperature = self._min_temp[self._mode]
 
         return convert_temperature(temperature, self._unit,
                                    self.hass.config.units.temperature_unit)
@@ -249,8 +279,8 @@ class TadoClimate(ClimateDevice):
         """Return the maximum temperature."""
         temperature = DEFAULT_MAX_TEMP
 
-        if self._max_temp:
-            temperature = self._max_temp
+        if self._mode in self._max_temp:
+            temperature = self._max_temp[self._mode]
 
         return convert_temperature(temperature, self._unit,
                                    self.hass.config.units.temperature_unit)
@@ -308,8 +338,7 @@ class TadoClimate(ClimateDevice):
         overlay = False
         overlay_data = None
         termination = CONST_MODE_SMART_SCHEDULE
-        cooling = False
-        ac_mode = None
+        mode = CONST_MODE_HEAT
         fan_speed = CONST_MODE_OFF
 
         if 'overlay' in data:
@@ -325,8 +354,7 @@ class TadoClimate(ClimateDevice):
 
             if setting:
                 if 'mode' in setting_data:
-                    cooling = setting_data['mode'] == 'COOL'
-                    ac_mode = setting_data['mode']
+                    mode = setting_data['mode']
 
                 if 'fanSpeed' in setting_data:
                     fan_speed = setting_data['fanSpeed']
@@ -337,8 +365,7 @@ class TadoClimate(ClimateDevice):
             self._overlay_mode = termination
             self._current_operation = termination
 
-        self._cooling = cooling
-        self._ac_mode = ac_mode
+        self._mode = mode
         self._current_fan = fan_speed
 
     def _control_heating(self):
@@ -362,7 +389,7 @@ class TadoClimate(ClimateDevice):
         if self._current_operation == CONST_MODE_OFF:
             _LOGGER.info("Switching mytado.com to OFF for zone %s",
                          self.zone_name)
-            self._store.set_zone_overlay(self.zone_id, self.device_type, CONST_OVERLAY_MANUAL)
+            self._store.set_zone_overlay(self.zone_id, self._device_type, CONST_OVERLAY_MANUAL)
             self._overlay_mode = self._current_operation
             return
 
@@ -370,6 +397,6 @@ class TadoClimate(ClimateDevice):
                      self._current_operation, self.zone_name)
 
         self._store.set_zone_overlay(
-            self.zone_id, self.device_type, self._current_operation, self._target_temp, self._ac_mode, self._device_is_active)
+            self.zone_id, self._device_type, self._current_operation, self._target_temp, None, self._mode, self._device_is_active)
 
         self._overlay_mode = self._current_operation

--- a/homeassistant/components/climate/tado.py
+++ b/homeassistant/components/climate/tado.py
@@ -199,6 +199,8 @@ class TadoClimate(ClimateDevice):
         if self._current_operation in OPERATION_MANUAL:
             if self._mode == CONST_MODE_COOL:
                 return OPERATION_MANUAL_COOL.get(self._current_operation)
+            elif self._device_type == "HOT_WATER" and not self._is_manual_temperature:
+                return OPERATION_MANUAL_HOT_WATER_ON.get(self._current_operation)
             return OPERATION_MANUAL.get(self._current_operation)
         return OPERATION_LIST.get(self._current_operation)
 
@@ -210,6 +212,8 @@ class TadoClimate(ClimateDevice):
             operations.extend(list(OPERATION_MANUAL_COOL.values()))
         elif CONST_MODE_HEAT in self._min_temp:
             operations.extend(list(OPERATION_MANUAL.values()))
+        elif self._device_type == "HOT_WATER" and not self._is_manual_temperature:
+            operations.extend(list(OPERATION_MANUAL_HOT_WATER_ON.values()))
         return operations
 
     @property

--- a/homeassistant/components/climate/tado.py
+++ b/homeassistant/components/climate/tado.py
@@ -370,6 +370,6 @@ class TadoClimate(ClimateDevice):
                      self._current_operation, self.zone_name)
 
         self._store.set_zone_overlay(
-            self.zone_id, self.device_type, self._current_operation, self._target_temp, self._ac_mode)
+            self.zone_id, self.device_type, self._current_operation, self._target_temp, self._ac_mode, self._device_is_active)
 
         self._overlay_mode = self._current_operation

--- a/homeassistant/components/climate/tado.py
+++ b/homeassistant/components/climate/tado.py
@@ -10,6 +10,7 @@ from homeassistant.const import (PRECISION_TENTHS, TEMP_CELSIUS)
 from homeassistant.components.climate import (
     ClimateDevice, SUPPORT_TARGET_TEMPERATURE, SUPPORT_OPERATION_MODE,
     DEFAULT_MIN_TEMP, DEFAULT_MAX_TEMP)
+from homeassistant.util.temperature import convert as convert_temperature
 from homeassistant.const import ATTR_TEMPERATURE
 from homeassistant.components.tado import DATA_TADO
 

--- a/homeassistant/components/sensor/tado.py
+++ b/homeassistant/components/sensor/tado.py
@@ -16,11 +16,15 @@ ATTR_DATA_ID = 'data_id'
 ATTR_DEVICE = 'device'
 ATTR_ZONE = 'zone'
 
+CLIMATE_ZONE = 'HEATING'
 CLIMATE_SENSOR_TYPES = ['temperature', 'humidity', 'power',
                         'link', 'heating', 'tado mode', 'overlay']
 
+HOT_WATER_ZONE = 'HOT_WATER'
 HOT_WATER_SENSOR_TYPES = ['power', 'link', 'tado mode', 'overlay']
 
+AIR_CONDITIONING_ZONE = 'AIR_CONDITIONING'
+AIR_CONDITIONING_SENSOR_TYPES = ['temperature', 'humidity', 'power', 'link', 'ac', 'tado mode', 'overlay']
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the sensor platform."""
@@ -34,12 +38,16 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     sensor_items = []
     for zone in zones:
-        if zone['type'] == 'HEATING':
+        if zone['type'] == CLIMATE_ZONE:
             for variable in CLIMATE_SENSOR_TYPES:
                 sensor_items.append(create_zone_sensor(
                     tado, zone, zone['name'], zone['id'], variable))
-        elif zone['type'] == 'HOT_WATER':
+        elif zone['type'] == HOT_WATER_ZONE:
             for variable in HOT_WATER_SENSOR_TYPES:
+                sensor_items.append(create_zone_sensor(
+                    tado, zone, zone['name'], zone['id'], variable))
+        elif zone['type'] == AIR_CONDITIONING_ZONE:
+            for variable in AIR_CONDITIONING_SENSOR_TYPES:
                 sensor_items.append(create_zone_sensor(
                     tado, zone, zone['name'], zone['id'], variable))
 
@@ -195,6 +203,14 @@ class TadoSensor(Entity):
                     activity_data['heatingPower']['percentage'])
                 self._state_attributes = {
                     "time": activity_data['heatingPower']['timestamp'],
+                }
+
+        elif self.zone_variable == 'ac':
+            if 'activityDataPoints' in data:
+                activity_data = data['activityDataPoints']
+                self._state = activity_data['acPower']['value']
+                self._state_attributes = {
+                    "time": activity_data['acPower']['timestamp'],
                 }
 
         elif self.zone_variable == 'tado bridge status':

--- a/homeassistant/components/tado.py
+++ b/homeassistant/components/tado.py
@@ -122,12 +122,8 @@ class TadoDataStore:
         self.tado.resetZoneOverlay(zone_id)
         self.update(no_throttle=True)  # pylint: disable=unexpected-keyword-arg
 
-    def set_zone_overlay(self, zone_id, ac_mode, overlay_mode, temperature=None, duration=None):
+    def set_zone_overlay(self, zone_id, device_type, overlay_mode, temperature=None, duration=None, ac_mode=None):
         """Wrap for setZoneOverlay(..)."""
-        device_type = 'HEATING'
-
-        if ac_mode:
-            device_type = 'AIR_CONDITIONING'
 
         power = "ON" 
         if temperature is None:
@@ -135,5 +131,5 @@ class TadoDataStore:
         
         mode = None
 
-        self.tado.setZoneOverlay(zone_id, overlay_mode, temperature, duration, device_type, power, mode)
+        self.tado.setZoneOverlay(zone_id, overlay_mode, temperature, duration, device_type, ac_mode)
         self.update(no_throttle=True)  # pylint: disable=unexpected-keyword-arg

--- a/homeassistant/components/tado.py
+++ b/homeassistant/components/tado.py
@@ -122,14 +122,15 @@ class TadoDataStore:
         self.tado.resetZoneOverlay(zone_id)
         self.update(no_throttle=True)  # pylint: disable=unexpected-keyword-arg
 
-    def set_zone_overlay(self, zone_id, device_type, overlay_mode, temperature=None, duration=None, ac_mode=None):
+    def set_zone_overlay(self, zone_id, device_type, overlay_mode, temperature=None, duration=None, ac_mode=None, device_is_active=True):
         """Wrap for setZoneOverlay(..)."""
 
         power = "ON" 
-        if temperature is None:
+        if device_type == "HOT_WATER":
+            if device_is_active:
+                power = "OFF"
+        elif temperature is None:
             power = "OFF"
-        
-        mode = None
 
-        self.tado.setZoneOverlay(zone_id, overlay_mode, temperature, duration, device_type, ac_mode)
+        self.tado.setZoneOverlay(zone_id, overlay_mode, temperature, duration, device_type, power, ac_mode)
         self.update(no_throttle=True)  # pylint: disable=unexpected-keyword-arg

--- a/homeassistant/components/tado.py
+++ b/homeassistant/components/tado.py
@@ -13,7 +13,6 @@ import voluptuous as vol
 from homeassistant.helpers.discovery import load_platform
 from homeassistant.helpers import config_validation as cv
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
-from homeassistant.util.temperature import convert as convert_temperature
 from homeassistant.util import Throttle
 
 REQUIREMENTS = ['python-tado==0.2.5']

--- a/homeassistant/components/tado.py
+++ b/homeassistant/components/tado.py
@@ -15,7 +15,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['python-tado==0.2.5']
+REQUIREMENTS = ['python-tado==0.2.6']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -122,7 +122,7 @@ class TadoDataStore:
         self.tado.resetZoneOverlay(zone_id)
         self.update(no_throttle=True)  # pylint: disable=unexpected-keyword-arg
 
-    def set_zone_overlay(self, zone_id, device_type, overlay_mode, temperature=None, duration=None, ac_mode=None, device_is_active=True):
+    def set_zone_overlay(self, zone_id, device_type, overlay_mode, temperature=None, duration=None, mode=None, device_is_active=True):
         """Wrap for setZoneOverlay(..)."""
 
         power = "ON" 
@@ -132,5 +132,5 @@ class TadoDataStore:
         elif temperature is None:
             power = "OFF"
 
-        self.tado.setZoneOverlay(zone_id, overlay_mode, temperature, duration, device_type, power, ac_mode)
+        self.tado.setZoneOverlay(zone_id, overlay_mode, temperature, duration, device_type, power, mode)
         self.update(no_throttle=True)  # pylint: disable=unexpected-keyword-arg

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1186,7 +1186,7 @@ python-songpal==0.0.8
 python-synology==0.2.0
 
 # homeassistant.components.tado
-python-tado==0.2.5
+python-tado==0.2.6
 
 # homeassistant.components.telegram_bot
 python-telegram-bot==11.1.0


### PR DESCRIPTION
## Description:
Added the essential sensors from AC
![visual](https://user-images.githubusercontent.com/6518915/47314665-3cb8ee80-d63a-11e8-879b-0532fe519bc2.png)

![ac_sensor](https://user-images.githubusercontent.com/6518915/47314640-24e16a80-d63a-11e8-8992-5e2ec305af5a.png)

AC mode with 'COOL' has seperate 'COOL' option.
![ac_cool_mode](https://user-images.githubusercontent.com/6518915/47651220-80e84980-db7a-11e8-82f5-0615b9526ff0.png)

Requires changes to PyTado to correctly send the required AC API call
https://github.com/wmalgadey/PyTado/commit/5925c9f8b9e50648b8d9ad2bf0810c51bd4a98f3
~~chrism0dwk/PyTado#5~~

Will Resolve
wmalgadey/tado_component#23
home-assistant/home-assistant#6943

## Checklist:
  - [ ] Ensure the latest PyTado 0.2.6 is loaded (IMPORTANT)
  - [x] Fix controlling AC climate API (@wmalgadey has already worked on it via his own PyTado branch)
  - [x] Added AC sensors
  - [x] Fix AC operation mode, 'HEAT' and 'COOL', 'COOL' or 'HEAT' is supported
  - [ ] Fix HOT_WATER without that has false canSetTemperature, cannot test as I don't have HOT_WATER
  - [x] To control climate, API requires extra parameters that are found the updated PyTado (v2.5 https://github.com/wmalgadey/PyTado/commit/5925c9f8b9e50648b8d9ad2bf0810c51bd4a98f3  ~~chrism0dwk/PyTado#5~~)