### PR TITLE
Fixing hot water

### DIFF
--- a/homeassistant/components/climate/tado.py
+++ b/homeassistant/components/climate/tado.py
@@ -409,7 +409,7 @@ class TadoClimate(ClimateDevice):
             _LOGGER.info("Obtained current and target temperature. "
                          "Tado thermostat active")
 
-        if not self._active or self._current_operation == self._overlay_mode:
+        if not self._active and not self._device_type == "HOT_WATER" or self._current_operation == self._overlay_mode:
             return
 
         if self._current_operation == CONST_MODE_SMART_SCHEDULE:
@@ -423,7 +423,7 @@ class TadoClimate(ClimateDevice):
             _LOGGER.info("Switching mytado.com to OFF for zone %s",
                          self.zone_name)
             self._store.set_zone_overlay(self.zone_id, self._device_type,
-                                         CONST_OVERLAY_MANUAL)
+                                         CONST_OVERLAY_MANUAL, None, None, None, "OFF")
             self._overlay_mode = self._current_operation
             return
 
@@ -436,6 +436,6 @@ class TadoClimate(ClimateDevice):
                                      self._target_temp,
                                      None,
                                      self._mode,
-                                     self._device_is_active)
+                                     "ON")
 
         self._overlay_mode = self._current_operation

--- a/homeassistant/components/tado.py
+++ b/homeassistant/components/tado.py
@@ -124,14 +124,8 @@ class TadoDataStore:
 
     def set_zone_overlay(
             self, zone_id, device_type, overlay_mode,
-            temperature=None, duration=None, mode=None, device_is_active=True):
+            temperature=None, duration=None, mode=None, power=True):
         """Wrap for setZoneOverlay(..)."""
-        power = "ON"
-        if device_type == "HOT_WATER":
-            if device_is_active:
-                power = "OFF"
-        elif temperature is None:
-            power = "OFF"
 
         self.tado.setZoneOverlay(zone_id,
                                  overlay_mode,


### PR DESCRIPTION


## Description:
With the old solution hot water was only able to switch to a temp or an active mode when it came from the off state. (Since as soon as device became active power would be OFF so you were never able to switch temp only when device was not active)

Hot water is now tested and works


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**



[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
