### PR TITLE
Allowing OFF to use different overlays

### DIFF
--- a/homeassistant/components/climate/tado.py
+++ b/homeassistant/components/climate/tado.py
@@ -424,7 +424,7 @@ class TadoClimate(ClimateDevice):
             _LOGGER.info("Switching mytado.com to OFF for zone %s",
                          self.zone_name)
             self._store.set_zone_overlay(self.zone_id, self._device_type,
-                                         CONST_OVERLAY_MANUAL,
+                                         self._current_operation,
                                          None, None, None,
                                          "OFF")
             self._overlay_mode = self._current_operation


### PR DESCRIPTION
I don't really see the point why OFF would only be allowed in manual. Also due to my automation as soon as smart schedule turns off the heat it would now automatically switch from Smart Schedule to Manual which is undesired and annoying. So this should fix that :)!

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
